### PR TITLE
Find by classification and id endpoint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ image_build:
 # May fail if the secret already exists
 # Only need one setup per namespace, so we do this in master only
 setup_environment:
-  image: ryarnyah/kubectl-aws
+  image: kokyj/kubectl-aws:1.14
   stage: setup
   environment:
     name: live
@@ -76,7 +76,7 @@ setup_environment:
     - kubectl create secret docker-registry regsecret --docker-server=${CI_REGISTRY} --docker-username=${CI_REGISTRY_USER} --docker-password=${CI_REGISTRY_PASSWORD} --docker-email=wesley.fowlks@kaleido.com --namespace ${CI_PROJECT_NAME}
 
 teardown_staging:
-    image: ryarnyah/kubectl-aws
+    image: kokyj/kubectl-aws:1.14
     stage: cleanup
     allow_failure: true
     environment:
@@ -107,7 +107,7 @@ teardown_staging:
         - kubectl delete -f service.yaml
 
 deploy_staging:
-    image: ryarnyah/kubectl-aws
+    image: kokyj/kubectl-aws:1.14
     stage: deploy
     environment:
         name: staging
@@ -147,7 +147,7 @@ deploy_staging:
         - kubectl get all,ing -l ref=${CI_ENVIRONMENT_SLUG}
 
 teardown_live:
-  image: ryarnyah/kubectl-aws
+  image: kokyj/kubectl-aws:1.14
   stage: cleanup
   allow_failure: true
   environment:
@@ -178,7 +178,7 @@ teardown_live:
 
 
 deploy_live:
-  image: ryarnyah/kubectl-aws
+  image: kokyj/kubectl-aws:1.14
   stage: deploy
   environment:
     name: live

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.kaleidobio</groupId>
     <artifactId>jarvis</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
     <name>jarvis</name>
     <description>Endpoint for Atlas that looks up components</description>
 

--- a/src/main/java/com/kaleido/jarvis/resource/JarvisResource.java
+++ b/src/main/java/com/kaleido/jarvis/resource/JarvisResource.java
@@ -5,14 +5,12 @@ import com.kaleido.kaptureclient.domain.*;
 import com.kaleido.jarvis.domain.Component;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 @RestController
@@ -24,7 +22,8 @@ public class JarvisResource {
     private KaptureClient<Batch> batchKaptureClient;
     private KaptureClient<Community> communityKaptureClient;
     private KaptureClient<Supplement> supplementKaptureClient;
-
+    
+    private static final int URI_BATCH_SIZE = 50;
     private static final String microLiter = "\u00B5L";
     private static final String microGram = "\u00B5g";
 
@@ -36,22 +35,22 @@ public class JarvisResource {
     }
 
     @GetMapping("/health")
-    public ResponseEntity<String> health(){
+    public ResponseEntity<String> health() {
         return ResponseEntity.ok("Alive");
     }
 
     @GetMapping("/components/search/{searchTerm}")
-    public ResponseEntity<List<Component>> searchComponents(@PathVariable String searchTerm){
+    public ResponseEntity<List<Component>> searchComponents(@PathVariable String searchTerm) {
         log.debug("call to /components/search/{}", searchTerm);
 
         final String originalSearchTerm = searchTerm;
 
         //add asterisks to the searchTerm if they are not already there
-        if(! searchTerm.startsWith("*")){
-            searchTerm = "*"+searchTerm;
+        if (!searchTerm.startsWith("*")) {
+            searchTerm = "*" + searchTerm;
         }
-        if(! searchTerm.endsWith("*")){
-            searchTerm = searchTerm+"*";
+        if (!searchTerm.endsWith("*")) {
+            searchTerm = searchTerm + "*";
         }
 
 
@@ -64,12 +63,12 @@ public class JarvisResource {
         var supplementComponents = CompletableFuture.supplyAsync(() -> searchSupplement(originalSearchTerm));
 
         var matches = Stream.of(mediaComponents, batchComponents, communityComponents, supplementComponents)
-                            //wait for all the futures to complete
-                            .map(CompletableFuture::join)
-                            //make a combined stream of components
-                            .flatMap(Collection::stream)
-                            //make a boolean make with two lists, those that have an exact match and those that don't
-                            .collect(Collectors.partitioningBy(component -> component.getName().equals(originalSearchTerm)));
+                //wait for all the futures to complete
+                .map(CompletableFuture::join)
+                //make a combined stream of components
+                .flatMap(Collection::stream)
+                //make a boolean make with two lists, those that have an exact match and those that don't
+                .collect(Collectors.partitioningBy(component -> component.getName().equals(originalSearchTerm)));
         //sort the matches that are not exact
         List<Component> sortedNonExactMatches = matches.get(false).stream()
                 .sorted(Comparator.comparing(Component::getName)
@@ -95,35 +94,151 @@ public class JarvisResource {
         return ResponseEntity.ok(results);
     }
 
+    @PostMapping("/components/find")
+    public ResponseEntity<List<Component>> getComponentsByClassificationAndId(@RequestBody List<Component> searchComponents) {
+        log.debug("call to /components/find : {}", searchComponents);
+
+
+        var mediaComponents = CompletableFuture.supplyAsync(() -> searchMediaByIds(
+                searchComponents.stream()
+                        .filter(searchComponent -> searchComponent.getClassification().equalsIgnoreCase("media"))
+                        .map(searchComponent -> searchComponent.getId())
+                        .collect(Collectors.toList())
+        ));
+        var batchComponents = CompletableFuture.supplyAsync(() -> searchBatchByIds(
+                searchComponents.stream()
+                        .filter(searchComponent -> searchComponent.getClassification().equalsIgnoreCase("batch"))
+                        .map(searchComponent -> searchComponent.getId())
+                        .collect(Collectors.toList())
+        ));
+        var communityComponents = CompletableFuture.supplyAsync(() -> searchCommunityByIds(
+                searchComponents.stream()
+                        .filter(searchComponent -> searchComponent.getClassification().equalsIgnoreCase("community"))
+                        .map(searchComponent -> searchComponent.getId())
+                        .collect(Collectors.toList())
+        ));
+        var supplementComponents = CompletableFuture.supplyAsync(() -> searchSupplementByIds(
+                searchComponents.stream()
+                        .filter(searchComponent -> searchComponent.getClassification().equalsIgnoreCase("supplement"))
+                        .map(searchComponent -> searchComponent.getId())
+                        .collect(Collectors.toList())
+        ));
+
+        List<Component> results = Stream.of(mediaComponents, batchComponents, communityComponents, supplementComponents)
+                //wait for all the futures to complete
+                .map(CompletableFuture::join)
+                //make a combined stream of components
+                .flatMap(Collection::stream)
+                //sort the matches
+                .sorted(Comparator.comparing(Component::getName)
+                        .thenComparing(Component::getClassification))
+                .collect(Collectors.toList());
+
+        log.debug("Sorted matches {}", results);
+
+        return ResponseEntity.ok(results);
+
+    }
+
+    private List<Component> searchMediaByIds(List<Long> mediaIds) {
+        List<Component> mediaList = new ArrayList();
+
+        IntStream.range(0, (mediaIds.size() + URI_BATCH_SIZE - 1) / URI_BATCH_SIZE)
+                .mapToObj(i -> mediaIds.subList(i * URI_BATCH_SIZE, Math.min(mediaIds.size(), (i + 1) * URI_BATCH_SIZE)))
+                .map(dataBatch -> dataBatch.stream()
+                        .map(mediaId -> mediaId.toString())
+                        .collect(Collectors.joining(","))
+                ).forEach(queryString -> {
+                    final var mediaResponse = mediaKaptureClient.findByFieldWithOperator("id", queryString, "in");
+                    if (mediaResponse.getStatusCode().is2xxSuccessful() && mediaResponse.getBody() != null) {
+                        //map the responses to a Component
+                        mediaList.addAll(mediaResponse.getBody().stream()
+                                .map(media -> buildMediaComponent(media))
+                                .collect(Collectors.toList()));
+                    }
+                }
+
+        );
+
+        return mediaList;
+    }
+
+    private List<Component> searchBatchByIds(List<Long> batchIds) {
+        List<Component> batchList = new ArrayList();
+
+        IntStream.range(0, (batchIds.size() + URI_BATCH_SIZE - 1) / URI_BATCH_SIZE)
+                .mapToObj(i -> batchIds.subList(i * URI_BATCH_SIZE, Math.min(batchIds.size(), (i + 1) * URI_BATCH_SIZE)))
+                .map(dataBatch -> dataBatch.stream()
+                        .map(batchId -> batchId.toString())
+                        .collect(Collectors.joining(","))
+                ).forEach(queryString -> {
+                    final var batchResponse = batchKaptureClient.findByFieldWithOperator("id", queryString, "in");
+                    if (batchResponse.getStatusCode().is2xxSuccessful() && batchResponse.getBody() != null) {
+                        //map the responses to a Component
+                        batchList.addAll(batchResponse.getBody().stream()
+                                .map(batch -> buildBatchComponent(batch))
+                                .collect(Collectors.toList()));
+                    }
+                }
+
+        );
+
+        return batchList;
+    }
+
+    private List<Component> searchCommunityByIds(List<Long> communityIds) {
+        List<Component> communityList = new ArrayList();
+
+        IntStream.range(0, (communityIds.size() + URI_BATCH_SIZE - 1) / URI_BATCH_SIZE)
+                .mapToObj(i -> communityIds.subList(i * URI_BATCH_SIZE, Math.min(communityIds.size(), (i + 1) * URI_BATCH_SIZE)))
+                .map(dataBatch -> dataBatch.stream()
+                        .map(communityId -> communityId.toString())
+                        .collect(Collectors.joining(","))
+                ).forEach(queryString -> {
+                    final var communityResponse = communityKaptureClient.findByFieldWithOperator("id", queryString, "in");
+                    if (communityResponse.getStatusCode().is2xxSuccessful() && communityResponse.getBody() != null) {
+                        //map the responses to a Component
+                        communityList.addAll(communityResponse.getBody().stream()
+                                .map(community -> buildCommunityComponent(community))
+                                .collect(Collectors.toList()));
+                    }
+                }
+
+        );
+
+        return communityList;
+    }
+
+    private List<Component> searchSupplementByIds(List<Long> supplementIds) {
+        List<Component> supplementList = new ArrayList();
+
+        IntStream.range(0, (supplementIds.size() + URI_BATCH_SIZE - 1) / URI_BATCH_SIZE)
+                .mapToObj(i -> supplementIds.subList(i * URI_BATCH_SIZE, Math.min(supplementIds.size(), (i + 1) * URI_BATCH_SIZE)))
+                .map(dataBatch -> dataBatch.stream()
+                        .map(supplementId -> supplementId.toString())
+                        .collect(Collectors.joining(","))
+                ).forEach(queryString -> {
+                    final var supplementResponse = supplementKaptureClient.findByFieldWithOperator("id", queryString, "in");
+                    if (supplementResponse.getStatusCode().is2xxSuccessful() && supplementResponse.getBody() != null) {
+                        //map the responses to a Component
+                        supplementList.addAll(supplementResponse.getBody().stream()
+                                .map(supplement -> buildSupplementComponent(supplement))
+                                .collect(Collectors.toList()));
+                    }
+                }
+
+        );
+
+        return supplementList;
+    }
+
     private List<Component> searchBatch(String searchTerm) {
         final var batchResponse = batchKaptureClient.search(searchTerm);
 
-        if(batchResponse.getStatusCode().is2xxSuccessful() && batchResponse.getBody() != null){
+        if (batchResponse.getStatusCode().is2xxSuccessful() && batchResponse.getBody() != null) {
             //map the responses to a Component
             return batchResponse.getBody().stream()
-                    .map(batch -> Component.builder()
-                            .classification("Compound")
-                            .classificationSymbol("Cpd")
-                            .id(batch.getId())
-                            .name(batch.getName())
-                            .altName(Optional.ofNullable(
-                                    batch.getAliases()
-                                    .stream()
-                                    .map(BatchAlias::getAlias)
-                                    .collect(Collectors.joining(","))).orElse(""))
-                            .toolTip(Map.of(
-                                    "Notebook", Optional.ofNullable(batch.getNotebook()),
-                                    "Glycan Composition", Optional.ofNullable(batch.getGlycanComposition()),
-                                    "Mw", Optional.ofNullable(batch.getMw()),
-                                    "AveDP", Optional.ofNullable(batch.getAveDP()),
-                                    "Concepts", Optional.ofNullable(
-                                            batch.getConcepts().stream()
-                                                    .map(ChemicalConcept::getConceptId)
-                                                    .collect(Collectors.joining(",")))
-                                    )
-                            )
-                            .allowedUnits(List.of(microLiter, "mL", "%"))
-                            .build())
+                    .map(batch -> buildBatchComponent(batch))
                     .collect(Collectors.toList());
 
         } else {
@@ -134,21 +249,10 @@ public class JarvisResource {
     private List<Component> searchCommunity(String searchTerm) {
         final var communityResponse = communityKaptureClient.findByFieldWithOperator("name", searchTerm, "contains");
 
-        if(communityResponse.getStatusCode().is2xxSuccessful() && communityResponse.getBody() != null){
+        if (communityResponse.getStatusCode().is2xxSuccessful() && communityResponse.getBody() != null) {
             //map the responses to a Component
             return communityResponse.getBody().stream()
-                    .map(community -> Component.builder()
-                            .classification("Community")
-                            .classificationSymbol("C")
-                            .name(community.getName())
-                            .altName(community.getAlias())
-                            .toolTip(Map.of(
-                                    "BSI Name", Optional.ofNullable(community.getBsiName()),
-                                    "Description", Optional.ofNullable(community.getDescription())
-                            ))
-                            .allowedUnits(List.of(microLiter, "mL", "%"))
-                            .build()
-                    )
+                    .map(community -> buildCommunityComponent(community))
                     .collect(Collectors.toList());
 
         } else {
@@ -159,22 +263,10 @@ public class JarvisResource {
     private List<Component> searchSupplement(String searchTerm) {
         final var supplementResponse = supplementKaptureClient.findByFieldWithOperator("name", searchTerm, "contains");
 
-        if(supplementResponse.getStatusCode().is2xxSuccessful() && supplementResponse.getBody() != null){
+        if (supplementResponse.getStatusCode().is2xxSuccessful() && supplementResponse.getBody() != null) {
             //map the responses to a Component
             return supplementResponse.getBody().stream()
-                    .map(supplement -> Component.builder()
-                            .id(supplement.getId())
-                            .classification("Supplement")
-                            .classificationSymbol("S")
-                            .name(supplement.getName())
-                            .altName("")
-                            .allowedUnits(List.of(microGram,"mg","g"))
-                            .toolTip(Map.of(
-                                    "Supplement class", Optional.ofNullable(supplement.getClassification()),
-                                    "Description", Optional.ofNullable(supplement.getDescription())
-                            ))
-                            .build()
-                    )
+                    .map(supplement -> buildSupplementComponent(supplement))
                     .collect(Collectors.toList());
 
         } else {
@@ -184,27 +276,89 @@ public class JarvisResource {
 
     private List<Component> searchMedia(String searchTerm) {
         final var mediaResponse = mediaKaptureClient.findByFieldWithOperator("name", searchTerm, "contains");
-        if(mediaResponse.getStatusCode().is2xxSuccessful() && mediaResponse.getBody() != null){
+        if (mediaResponse.getStatusCode().is2xxSuccessful() && mediaResponse.getBody() != null) {
             //map the responses to a Component
             return mediaResponse.getBody().stream()
-                    .map(media -> Component.builder()
-                            .id(media.getId())
-                            .classification("Media")
-                            .classificationSymbol("M")
-                            .name(media.getName())
-                            .altName("")
-                            .allowedUnits(List.of(microLiter, "mL", "%"))
-                            .toolTip(Map.of(
-                                    "Base Media", Optional.ofNullable(media.getBaseMedia() != null ? media.getBaseMedia().getName() : null),
-                                    "Description", Optional.ofNullable(media.getDescription()),
-                                    "pH", Optional.ofNullable(media.getPh())
-                            ))
-                            .build()
-                    )
+                    .map(media -> buildMediaComponent(media))
                     .collect(Collectors.toList());
 
         } else {
             return Collections.emptyList();
         }
     }
+
+    private Component buildMediaComponent(Media media) {
+        return Component.builder()
+                .id(media.getId())
+                .classification("Media")
+                .classificationSymbol("M")
+                .name(media.getName())
+                .altName("")
+                .allowedUnits(List.of(microLiter, "mL", "%"))
+                .toolTip(Map.of(
+                        "Base Media", Optional.ofNullable(media.getBaseMedia() != null ? media.getBaseMedia().getName() : null),
+                        "Description", Optional.ofNullable(media.getDescription()),
+                        "pH", Optional.ofNullable(media.getPh())
+                ))
+                .build();
+    }
+
+    private Component buildBatchComponent(Batch batch) {
+        return Component.builder()
+                .classification("Compound")
+                .classificationSymbol("Cpd")
+                .id(batch.getId())
+                .name(batch.getName())
+                .altName(Optional.ofNullable(
+                        batch.getAliases() == null ? null :
+                                batch.getAliases()
+                                .stream()
+                                .map(BatchAlias::getAlias)
+                                .collect(Collectors.joining(","))).orElse(""))
+                .toolTip(Map.of(
+                        "Notebook", Optional.ofNullable(batch.getNotebook()),
+                        "Glycan Composition", Optional.ofNullable(batch.getGlycanComposition()),
+                        "Mw", Optional.ofNullable(batch.getMw()),
+                        "AveDP", Optional.ofNullable(batch.getAveDP()),
+                        "Concepts", Optional.ofNullable(
+                                batch.getConcepts() == null ? null :
+                                batch.getConcepts().stream()
+                                        .map(ChemicalConcept::getConceptId)
+                                        .collect(Collectors.joining(",")))
+                        )
+                )
+                .allowedUnits(List.of(microLiter, "mL", "%"))
+                .build();
+    }
+
+    private Component buildCommunityComponent(Community community) {
+        return Component.builder()
+                .classification("Community")
+                .classificationSymbol("C")
+                .name(community.getName())
+                .altName(community.getAlias())
+                .toolTip(Map.of(
+                        "BSI Name", Optional.ofNullable(community.getBsiName()),
+                        "Description", Optional.ofNullable(community.getDescription())
+                ))
+                .allowedUnits(List.of(microLiter, "mL", "%"))
+                .build();
+    }
+
+    private Component buildSupplementComponent(Supplement supplement) {
+        return Component.builder()
+                .id(supplement.getId())
+                .classification("Supplement")
+                .classificationSymbol("S")
+                .name(supplement.getName())
+                .altName("")
+                .allowedUnits(List.of(microGram, "mg", "g"))
+                .toolTip(Map.of(
+                        "Supplement class", Optional.ofNullable(supplement.getClassification()),
+                        "Description", Optional.ofNullable(supplement.getDescription())
+                ))
+                .build();
+    }
+
+
 }


### PR DESCRIPTION
Added POST endpoint called /components/find to take in a list of components that have id and classification.  Will return a list of full component data for all matches.  Updated ci file to have new kubernetes configurations. Split component builders into their own functions and null checked some of the sets on batch to prevent null pointer exceptions when concepts or aliases are null