### PR TITLE
Added api to retrieve activity by name, and return as object instead …

### DIFF
--- a/src/main/java/com/kaleido/fetch/resource/ActivityResource.java
+++ b/src/main/java/com/kaleido/fetch/resource/ActivityResource.java
@@ -137,5 +137,15 @@ public class ActivityResource {
     @GetMapping("/activitySummary/{activityName}")
     public ResponseEntity<List<ActivitySummary>> getActivitySummary(@PathVariable String activityName) {
          return ResponseEntity.ok(activityService.getActivitySummaryList(activityName));
-     }
+    }
+    
+    @ApiOperation(value = "Retrieves the activity details based on given name")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful operation", response = Experiment.class),
+            @ApiResponse(code = 400, message = "Invalid status value")
+    })
+    @GetMapping("/{name}")
+    public ResponseEntity<ResponseEntity<Experiment>> getActivityId(@PathVariable String name) {
+         return ResponseEntity.ok(activityService.retrieveActivityByName(name));
+    }
 }

--- a/src/main/java/com/kaleido/fetch/service/ActivityService.java
+++ b/src/main/java/com/kaleido/fetch/service/ActivityService.java
@@ -196,12 +196,16 @@ public class ActivityService<E> {
         return activitySummaryList;
     }
     
-    public ResponseEntity<Experiment> retrieveActivityByName(String name) {
+    public ResponseEntity<E> retrieveActivityByName(String name) {
         HttpHeaders responseHeaders = new HttpHeaders();
         
         List<Experiment> response = (List<Experiment>) findActivities(name);
+        
+        if(response.isEmpty()) {
+            return (ResponseEntity<E>) new ResponseEntity<String>("No results found",responseHeaders, HttpStatus.NOT_FOUND);
+        }
 
-        return new ResponseEntity<Experiment>(response.get(0),responseHeaders, HttpStatus.OK);
+        return (ResponseEntity<E>) new ResponseEntity<Experiment>(response.get(0),responseHeaders, HttpStatus.OK);
     }
     
     private List<Experiment> searchExperiment(String searchTerm) {

--- a/src/main/java/com/kaleido/fetch/service/ActivityService.java
+++ b/src/main/java/com/kaleido/fetch/service/ActivityService.java
@@ -196,6 +196,14 @@ public class ActivityService<E> {
         return activitySummaryList;
     }
     
+    public ResponseEntity<Experiment> retrieveActivityByName(String name) {
+        HttpHeaders responseHeaders = new HttpHeaders();
+        
+        List<Experiment> response = (List<Experiment>) findActivities(name);
+
+        return new ResponseEntity<Experiment>(response.get(0),responseHeaders, HttpStatus.OK);
+    }
+    
     private List<Experiment> searchExperiment(String searchTerm) {
         final var mediaResponse = experimentKaptureClient.findByFieldWithOperator("name", searchTerm, "contains");
         return mediaResponse.getStatusCode().is2xxSuccessful() && mediaResponse.getBody() != null ?


### PR DESCRIPTION
API `activities/{name}` returns experiment as an object inside body of responseEntity instead of array, currently only uses activity name 